### PR TITLE
Optional types

### DIFF
--- a/dict_typer/convert.py
+++ b/dict_typer/convert.py
@@ -100,6 +100,11 @@ def convert(
                 return sequence_type
             if len(list_item_types) == 1:
                 return f"{sequence_type}[{list_item_types.pop()}]"
+            if len(list_item_types) == 2 and "None" in list_item_types:
+                list_item_types.discard("None")
+                typing_imports.add("Optional")
+                return f"{sequence_type}[Optional[{list_item_types.pop()}]]"
+
             union_type = f"Union[{', '.join(str(t) for t in sorted(list_item_types))}]"
             typing_imports.add("Union")
             return f"{sequence_type}[{union_type}]"

--- a/tests/snapshot/snapshots/snap_test_snapshots.py
+++ b/tests/snapshot/snapshots/snap_test_snapshots.py
@@ -316,7 +316,7 @@ class RootType(TypedDict):
     pageInfo: PageInfoType
     items: List[ItemsItemType]'''
 
-snapshots['test_snapshots[sitepoint.com.example4] 1'] = '''from typing import List
+snapshots['test_snapshots[sitepoint.com.example4] 1'] = '''from typing import List, Union
 
 from typing_extensions import TypedDict
 
@@ -341,16 +341,12 @@ class EntitiesType(TypedDict):
 
 
 class UrlType(TypedDict):
-    urls: List[UrlsItemType]
-
-
-class DescriptionType(TypedDict):
-    urls: List
+    urls: Union[List, List[UrlsItemType]]
 
 
 class EntitiesType(TypedDict):
     url: UrlType
-    description: DescriptionType
+    description: UrlType
 
 
 class UserType(TypedDict):

--- a/tests/unit/test_convert_basics.py
+++ b/tests/unit/test_convert_basics.py
@@ -85,22 +85,3 @@ def test_convert_none() -> None:
     # fmt: on
 
     assert convert(source) == expected
-
-
-def test_convert_list_with_none_as_optional() -> None:
-    source = {"items": [1, 2, None, 3], "mixedItems": [1, "2", None, "4", 5]}
-
-    # fmt: off
-    expected = "\n".join([
-        "from typing import List, Union",
-        "",
-        "from typing_extensions import TypedDict",
-        "",
-        "",
-        "class RootType(TypedDict):",
-        "    items: List[Union[None, int]]",
-        "    mixedItems: List[Union[None, int, str]]",
-    ])
-    # fmt: on
-
-    assert convert(source) == expected

--- a/tests/unit/test_convert_dict_in_sequence.py
+++ b/tests/unit/test_convert_dict_in_sequence.py
@@ -51,3 +51,25 @@ def test_convert_list_of_mixed_dicts() -> None:
     # fmt: on
 
     assert convert(source) == expected
+
+
+def test_convert_list_of_repeated_dicts_different_types_combined() -> None:
+    source = {"dictList": [{"id": 123}, {"id": 456.0}, {"id": "789"}]}
+
+    # fmt: off
+    expected = "\n".join([
+        "from typing import List, Union",
+        "",
+        "from typing_extensions import TypedDict",
+        "",
+        "",
+        "class DictListItemType(TypedDict):",
+        "    id: Union[float, int, str]",
+        "",
+        "",
+        "class RootType(TypedDict):",
+        "    dictList: List[DictListItemType]",
+    ])
+    # fmt: on
+
+    assert convert(source) == expected

--- a/tests/unit/test_convert_optional.py
+++ b/tests/unit/test_convert_optional.py
@@ -1,0 +1,49 @@
+from dict_typer import convert
+
+
+def test_convert_single_optional_in_list() -> None:
+    source = [1, 2, None, 3, 4, None, 5, 6]
+
+    # fmt: off
+    expected = "\n".join([
+        "from typing import List, Optional",
+        "",
+        "",
+        "RootType = List[Optional[int]]",
+    ])
+    # fmt: on
+
+    assert convert(source) == expected
+
+
+def test_convert_not_optional_if_multiple_types_with_none() -> None:
+    source = [1, 2, None, 3.0, 4.0, None, 5, 6]
+
+    # fmt: off
+    expected = "\n".join([
+        "from typing import List, Union",
+        "",
+        "",
+        "RootType = List[Union[None, float, int]]",
+    ])
+    # fmt: on
+
+    assert convert(source) == expected
+
+
+def test_convert_optional_combined_dicts() -> None:
+    source = [{"value": "foo"}, {"value": None}]
+
+    # fmt: off
+    expected = "\n".join([
+        "from typing_extensions import TypedDict",
+        "",
+        "",
+        "class RootTypeItem(TypedDict):"
+        "    value: Optional[str]",
+        ""
+        "RootType = List[RootTypeItem]",
+    ])
+    # fmt: on
+
+    assert convert(source) == expected

--- a/tests/unit/test_convert_optional.py
+++ b/tests/unit/test_convert_optional.py
@@ -1,3 +1,5 @@
+import pytest
+
 from dict_typer import convert
 
 
@@ -32,17 +34,26 @@ def test_convert_not_optional_if_multiple_types_with_none() -> None:
 
 
 def test_convert_optional_combined_dicts() -> None:
-    source = [{"value": "foo"}, {"value": None}]
+    source = {
+        "owner": {"name": "foo", "age": 44},
+        "coOwner": {"name": "bar", "age": None},
+    }
 
     # fmt: off
     expected = "\n".join([
+        "from typing import Union",
+        "",
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootTypeItem(TypedDict):"
-        "    value: Optional[str]",
-        ""
-        "RootType = List[RootTypeItem]",
+        "class OwnerType(TypedDict):",
+        "    name: str",
+        "    age: Optional[int]",
+        "",
+        "",
+        "class RootType(TypedDict):",
+        "    owner: OwnerType",
+        "    coOwner: OwnerType",
     ])
     # fmt: on
 

--- a/tests/unit/test_convert_optional.py
+++ b/tests/unit/test_convert_optional.py
@@ -1,5 +1,3 @@
-import pytest
-
 from dict_typer import convert
 
 

--- a/tests/unit/test_models_typed_definition.py
+++ b/tests/unit/test_models_typed_definition.py
@@ -1,8 +1,14 @@
-from dict_typer.models import TypedDefinion
+from dict_typer.models import MemberDefinition, TypedDefinion
 
 
 def test_typed_definition_printable_primary() -> None:
-    td = TypedDefinion(name="TestType", members=[("foo", "str"), ("bar", "int")])
+    td = TypedDefinion(
+        name="TestType",
+        members=[
+            MemberDefinition(name="foo", types=["str"]),
+            MemberDefinition(name="bar", types=["int"]),
+        ],
+    )
 
     # fmt: off
     expected = "\n".join([
@@ -16,7 +22,13 @@ def test_typed_definition_printable_primary() -> None:
 
 
 def test_typed_definition_printable_alternative() -> None:
-    td = TypedDefinion(name="TestType", members=[("foo", "str"), ("bar", "int")])
+    td = TypedDefinion(
+        name="TestType",
+        members=[
+            MemberDefinition(name="foo", types=["str"]),
+            MemberDefinition(name="bar", types=["int"]),
+        ],
+    )
 
     # fmt: off
     expected = "\n".join([
@@ -32,7 +44,11 @@ def test_typed_definition_printable_alternative() -> None:
 
 def test_typed_definition_printable_forces_alternative_if_invalid() -> None:
     td = TypedDefinion(
-        name="TestType", members=[("foo-bar", "str"), ("baz-qux", "int")]
+        name="TestType",
+        members=[
+            MemberDefinition(name="foo-bar", types=["str"]),
+            MemberDefinition(name="baz-qux", types=["int"]),
+        ],
     )
 
     # fmt: off


### PR DESCRIPTION
Support additional types, that is, instead of `Union[None, str]` it will be set as `Optional[str]`. More than one type will keep `Union` with `None` in there though, rather than `Optional[Union[str, int]]`

Dictionaries with the same keys will also be combined, so that 

`[{"foo": "bar"}, {"foo": 123}]`

is detected as a list of just one type

```python
class ItemType(DictType):
    foo: Union[str, int]
```

and

`[{"foo": "bar"}, {"foo": None}]`

is

```python
class ItemType(DictType):
    foo: Optional[str]
```

## TODO

support detecting types from empty lists if possible, so that

`[{"foo": []}, {"foo": [1, 2, 3}]`

is detected as a single dict type with `foo: List[int]` instead of `foo: Union[List, List[int]]`