### PR TITLE
Support empty dicts

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,4 +1,5 @@
 #!/bin/bash
 echo "Checking if code lints..."
-make lint
+poetry run mypy dict_typer tests/*
+poetry run flake8 dict_typer tests/*
 echo ""

--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ In [1]: source = {
    ...: }
    ...:
 
-In [2]: from dict_typer import convert
+In [2]: from dict_typer import get_type_definitions
 
-In [3]: print(convert(source, show_imports=True))
+In [3]: print(get_type_definitions(source, show_imports=True))
 from typing import List, Union
 
 from typing_extensions import TypedDict

--- a/dict_typer/__init__.py
+++ b/dict_typer/__init__.py
@@ -5,7 +5,7 @@ from typing import Dict, Tuple
 
 import click
 
-from dict_typer.convert import convert
+from dict_typer.type_definitions import get_type_definitions
 
 __version__ = "0.1.7"
 
@@ -36,6 +36,6 @@ def cli(file: Tuple[io.TextIOWrapper], imports: bool = True) -> None:
     except json.decoder.JSONDecodeError as e:
         raise click.UsageError(f"JSON serialisation error \n\n{e}")
 
-    output = convert(parsed, show_imports=imports)
+    output = get_type_definitions(parsed, show_imports=imports)
 
     click.echo(output)

--- a/dict_typer/models.py
+++ b/dict_typer/models.py
@@ -115,6 +115,8 @@ class DictEntry:
         self.force_alternative = force_alternative
 
     def get_imports(self) -> Set[str]:
+        if not self.members:
+            return {"Dict"}
         imports = set()
         for sub_members in self.members.values():
             for sub_member in sub_members:
@@ -163,6 +165,9 @@ class DictEntry:
         return f"<DictEntry ({self.name})>"
 
     def __str__(self) -> str:
+        if not self.members:
+            return ""
+
         out: List[str] = []
 
         if self.force_alternative or self.any_invalid_key():

--- a/dict_typer/models.py
+++ b/dict_typer/models.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional, Set, TypeVar
 
 from dict_typer.utils import is_valid_key
 
-KNOWN_TYPE_IMPORTS = ("List", "Tuple", "Set", "FrozenSet")
+KNOWN_TYPE_IMPORTS = ("List", "Tuple", "Set", "FrozenSet", "Dict")
 
 
 EntryType = TypeVar("EntryType", "MemberEntry", "DictEntry")

--- a/dict_typer/models.py
+++ b/dict_typer/models.py
@@ -138,6 +138,8 @@ class DictEntry:
 
     @property
     def depends_on(self) -> Set[str]:
+        if not self.members:
+            return set()
         members = set.union(*self.members.values())
         return set.union(*[m.depends_on for m in members], {m.name for m in members})
 

--- a/dict_typer/type_definitions.py
+++ b/dict_typer/type_definitions.py
@@ -203,7 +203,7 @@ class DefinitionBuilder:
         return self._output
 
 
-def convert(
+def get_type_definitions(
     source: Union[Dict, List],
     root_type_name: str = "Root",
     type_postfix: str = "Type",

--- a/dict_typer/type_definitions.py
+++ b/dict_typer/type_definitions.py
@@ -141,6 +141,8 @@ class DefinitionBuilder:
             return MemberEntry(sequence_type_name, sub_members=list_item_types)
 
         if isinstance(item, dict):
+            if item == {}:
+                return MemberEntry("Dict")
             return self._convert_dict(
                 f"{key_to_class_name(key)}{self.type_postfix}", item
             )

--- a/dict_typer/type_definitions.py
+++ b/dict_typer/type_definitions.py
@@ -173,7 +173,7 @@ class DefinitionBuilder:
             typed_dict_import = False
 
             for definition in self.definitions:
-                if isinstance(definition, DictEntry):
+                if isinstance(definition, DictEntry) and definition.members:
                     typed_dict_import = True
                 typing_imports |= definition.get_imports()
             if self.root_list:
@@ -199,6 +199,11 @@ class DefinitionBuilder:
                 if len(self.definitions):
                     self._output += "\n\n"
             self._output += f"{self.root_type_name}{self.type_postfix} = {sub_members_to_string(self.root_list)}"
+        # Special case with root being empty Dict
+        if self.source == {}:
+            if len(self._output):
+                self._output += "\n"
+            self._output += f"{self.root_type_name}{self.type_postfix} = Dict"
 
         return self._output
 

--- a/tests/e2e/test_full.py
+++ b/tests/e2e/test_full.py
@@ -1,7 +1,7 @@
 import subprocess
 import tempfile
 
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 # fmt: off
 TEST_SOURCE = {
@@ -46,7 +46,7 @@ def test_script_runs_with_nonzero() -> None:
     source_type_name = "Test"
     type_postfix = "Type"
 
-    output = convert(
+    output = get_type_definitions(
         TEST_SOURCE,
         root_type_name=source_type_name,
         type_postfix=type_postfix,
@@ -100,7 +100,7 @@ def test_mypy_has_no_issues() -> None:
     source_type_name = "Test"
     type_postfix = "Type"
 
-    output = convert(
+    output = get_type_definitions(
         TEST_SOURCE,
         root_type_name=source_type_name,
         type_postfix=type_postfix,

--- a/tests/snapshot/test_snapshots.py
+++ b/tests/snapshot/test_snapshots.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Union
 
 import pytest
 
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def get_f(num: int) -> Union[Dict, List]:
@@ -34,6 +34,6 @@ def test_snapshots(snapshot: Any, fixture: str) -> None:
     with open(f"tests/snapshot/fixtures/{fixture}.json", "r") as f:
         source = json.load(f)
 
-    output = convert(source)
+    output = get_type_definitions(source)
 
     snapshot.assert_match(output)

--- a/tests/unit/test_convert_basics.py
+++ b/tests/unit/test_convert_basics.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from dict_typer import convert
 
 

--- a/tests/unit/test_convert_basics.py
+++ b/tests/unit/test_convert_basics.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from dict_typer import get_type_definitions
 
 

--- a/tests/unit/test_convert_basics.py
+++ b/tests/unit/test_convert_basics.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_simple_json() -> None:
@@ -18,7 +18,7 @@ def test_convert_simple_json() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_base_types() -> None:
@@ -70,7 +70,7 @@ def test_convert_base_types() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_none() -> None:
@@ -86,4 +86,4 @@ def test_convert_none() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)

--- a/tests/unit/test_convert_dict_in_sequence.py
+++ b/tests/unit/test_convert_dict_in_sequence.py
@@ -1,4 +1,4 @@
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_list_of_repeated_dicts() -> None:
@@ -20,7 +20,7 @@ def test_convert_list_of_repeated_dicts() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_list_of_mixed_dicts() -> None:
@@ -50,7 +50,7 @@ def test_convert_list_of_mixed_dicts() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_list_of_repeated_dicts_different_types_combined() -> None:
@@ -72,4 +72,4 @@ def test_convert_list_of_repeated_dicts_different_types_combined() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)

--- a/tests/unit/test_convert_dicts.py
+++ b/tests/unit/test_convert_dicts.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_empty_root_dict() -> None:
@@ -15,7 +15,7 @@ def test_convert_empty_root_dict() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_nested_empty_dict() -> None:
@@ -33,7 +33,7 @@ def test_convert_with_nested_empty_dict() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_nested_dict() -> None:
@@ -53,7 +53,7 @@ def test_convert_with_nested_dict() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_multiple_levels_nested_dict() -> None:
@@ -81,7 +81,7 @@ def test_convert_with_multiple_levels_nested_dict() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_multiple_nested_dict() -> None:
@@ -106,7 +106,7 @@ def test_convert_with_multiple_nested_dict() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_repeated_nested_dict() -> None:
@@ -136,7 +136,7 @@ def test_convert_with_repeated_nested_dict() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_nested_overlapping_dict() -> None:
@@ -168,4 +168,4 @@ def test_convert_nested_overlapping_dict() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)

--- a/tests/unit/test_convert_dicts.py
+++ b/tests/unit/test_convert_dicts.py
@@ -1,4 +1,39 @@
+from typing import Dict
+
 from dict_typer import convert
+
+
+def test_convert_empty_root_dict() -> None:
+    source: Dict = {}
+
+    # fmt: off
+    expected = "\n".join([
+        "from typing import Dict",
+        "",
+        "",
+        "RootType = Dict",
+    ])
+    # fmt: on
+
+    assert expected == convert(source)
+
+
+def test_convert_with_nested_empty_dict() -> None:
+    source: Dict = {"nest": {}}
+
+    # fmt: off
+    expected = "\n".join([
+        "from typing import Dict",
+        "",
+        "from typing_extensions import TypedDict",
+        "",
+        "",
+        "class RootType(TypedDict):",
+        "    nest: Dict",
+    ])
+    # fmt: on
+
+    assert expected == convert(source)
 
 
 def test_convert_with_nested_dict() -> None:

--- a/tests/unit/test_convert_imports.py
+++ b/tests/unit/test_convert_imports.py
@@ -1,4 +1,4 @@
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_hides_import_optionally() -> None:
@@ -17,7 +17,7 @@ def test_convert_hides_import_optionally() -> None:
     ])
     # fmt: on
 
-    assert convert(source, show_imports=False) == expected
+    assert get_type_definitions(source, show_imports=False) == expected
 
 
 def test_convert_optionally_adds_imports_with_nested_defs() -> None:
@@ -40,7 +40,7 @@ def test_convert_optionally_adds_imports_with_nested_defs() -> None:
     ])
     # fmt: on
 
-    assert convert(source, show_imports=True) == expected
+    assert get_type_definitions(source, show_imports=True) == expected
 
 
 def test_convert_imports_with_no_typing_imports() -> None:
@@ -57,7 +57,7 @@ def test_convert_imports_with_no_typing_imports() -> None:
     ])
     # fmt: on
 
-    assert convert(source, show_imports=True) == expected
+    assert get_type_definitions(source, show_imports=True) == expected
 
 
 def test_convert_imports_with_no_typed_dict() -> None:
@@ -72,4 +72,4 @@ def test_convert_imports_with_no_typed_dict() -> None:
     ])
     # fmt: on
 
-    assert convert(source, show_imports=True) == expected
+    assert get_type_definitions(source, show_imports=True) == expected

--- a/tests/unit/test_convert_lists.py
+++ b/tests/unit/test_convert_lists.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_with_empty_list() -> None:
@@ -18,7 +18,7 @@ def test_convert_with_empty_list() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_empty_root_list() -> None:
@@ -33,7 +33,7 @@ def test_convert_empty_root_list() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_simple_list() -> None:
@@ -51,7 +51,7 @@ def test_convert_with_simple_list() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_mixed_list() -> None:
@@ -69,4 +69,4 @@ def test_convert_with_mixed_list() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)

--- a/tests/unit/test_convert_lists.py
+++ b/tests/unit/test_convert_lists.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from dict_typer import convert
 
 
@@ -13,6 +15,21 @@ def test_convert_with_empty_list() -> None:
         "",
         "class RootType(TypedDict):",
         "    items: List",
+    ])
+    # fmt: on
+
+    assert expected == convert(source)
+
+
+def test_convert_empty_root_list() -> None:
+    source: List = []
+
+    # fmt: off
+    expected = "\n".join([
+        "from typing import List",
+        "",
+        "",
+        "RootType = List",
     ])
     # fmt: on
 

--- a/tests/unit/test_convert_optional.py
+++ b/tests/unit/test_convert_optional.py
@@ -1,4 +1,4 @@
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_single_optional_in_list() -> None:
@@ -13,7 +13,7 @@ def test_convert_single_optional_in_list() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_not_optional_if_multiple_types_with_none() -> None:
@@ -28,7 +28,7 @@ def test_convert_not_optional_if_multiple_types_with_none() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_optional_combined_dicts() -> None:
@@ -55,4 +55,4 @@ def test_convert_optional_combined_dicts() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)

--- a/tests/unit/test_convert_root_list.py
+++ b/tests/unit/test_convert_root_list.py
@@ -1,4 +1,4 @@
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_root_list_single_item() -> None:
@@ -19,7 +19,7 @@ def test_convert_root_list_single_item() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_root_list_multiple_items() -> None:
@@ -44,7 +44,7 @@ def test_convert_root_list_multiple_items() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_root_list_multiple_mixed_items() -> None:
@@ -74,7 +74,7 @@ def test_convert_root_list_multiple_mixed_items() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_root_list_mixed_non_dict() -> None:
@@ -89,4 +89,4 @@ def test_convert_root_list_mixed_non_dict() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)

--- a/tests/unit/test_convert_set.py
+++ b/tests/unit/test_convert_set.py
@@ -1,4 +1,4 @@
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_with_empty_set() -> None:
@@ -16,7 +16,7 @@ def test_convert_with_empty_set() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_simple_set() -> None:
@@ -34,7 +34,7 @@ def test_convert_with_simple_set() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_mixed_set() -> None:
@@ -52,4 +52,4 @@ def test_convert_with_mixed_set() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)

--- a/tests/unit/test_convert_tuple.py
+++ b/tests/unit/test_convert_tuple.py
@@ -1,4 +1,4 @@
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_with_empty_tuple() -> None:
@@ -16,7 +16,7 @@ def test_convert_with_empty_tuple() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_simple_tuple() -> None:
@@ -34,7 +34,7 @@ def test_convert_with_simple_tuple() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_mixed_tuple() -> None:
@@ -52,4 +52,4 @@ def test_convert_with_mixed_tuple() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)

--- a/tests/unit/test_convert_with_invalid_key_names.py
+++ b/tests/unit/test_convert_with_invalid_key_names.py
@@ -1,4 +1,4 @@
-from dict_typer import convert
+from dict_typer import get_type_definitions
 
 
 def test_convert_with_invalid_key_names() -> None:
@@ -16,7 +16,7 @@ def test_convert_with_invalid_key_names() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)
 
 
 def test_convert_with_invalid_key_names_nested() -> None:
@@ -37,4 +37,4 @@ def test_convert_with_invalid_key_names_nested() -> None:
     ])
     # fmt: on
 
-    assert expected == convert(source)
+    assert expected == get_type_definitions(source)


### PR DESCRIPTION
```
-> % echo '{}' | p run dict-typer
from typing import Dict


RootType = Dict
```
```
-> % echo '{"foo": {}}' | p run dict-typer
from typing import Dict

from typing_extensions import TypedDict


class RootType(TypedDict):
    foo: Dict
```