### PR TITLE
Drop type postfix

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -1,5 +1,6 @@
 #!/bin/bash
 echo "Checking if code lints..."
-poetry run mypy dict_typer tests/*
-poetry run flake8 dict_typer tests/*
-echo ""
+xargs -P 4 -I {} sh -c 'eval "$1"' - {} <<'EOF'
+make mypy
+make flake8
+EOF

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ example, if we take the output generated from the Example section below and
 imagine it's a response we get from an api. We can plug it in like this:
 
 ```python
-from project.types import RootType
+from project.types import Root
 
 
-def get_from_api() -> RootType:
+def get_from_api() -> Root:
     pass
 
 
@@ -39,7 +39,7 @@ and if we run mypy on this
 ```shell
 -> % poetry run mypy test.py
 test.py:43: error: Unsupported operand types for + ("str" and "int")
-test.py:44: error: TypedDict "NestedDictType" has no key 'non_existant'
+test.py:44: error: TypedDict "NestedDict" has no key 'non_existant'
 test.py:46: error: Unsupported operand types for + ("None" and "int")
 test.py:46: error: Unsupported operand types for + ("str" and "int")
 test.py:46: note: Left operand is of type "Union[None, int, str]"
@@ -58,6 +58,7 @@ Either supply a path to a file or pipe json output to `dict-typer`
 
 ```help
 -> % dict-typer --help
+
 Usage: dict-typer [OPTIONS] [FILE]...
 
 Options:
@@ -93,7 +94,7 @@ which is valid json, but has the invalid identifier `numeric-id` and reserved
 keyword `from`, meaning the definition
 
 ```python
-class RootType(TypedDict):
+class Root(TypedDict):
     numeric-id: int
     from: str
 ```
@@ -103,7 +104,7 @@ way](https://www.python.org/dev/peps/pep-0589/#alternative-syntax) to define
 those types, looking like this
 
 ```python
-RootType = TypedDict('TypedDict', {'numeric-id': int, 'from': str'})
+Root = TypedDict('Root', {'numeric-id': int, 'from': str'})
 ```
 
 which is not as readable, but valid.
@@ -123,10 +124,10 @@ the type of the list. For example, the list `[1, "2", 3.0, { "id": 123 }, {
 from typing_extensions import TypedDict
 
 
-class RootItemType(TypedDict):
+class RootItem(TypedDict):
     id: int
 
-RootType = List[Union[RootItemType, float, int, str]]
+Root = List[Union[RootItem, float, int, str]]
 ```
 
 ## Examples
@@ -167,35 +168,35 @@ from typing import List, Union
 from typing_extensions import TypedDict
 
 
-class NestedDictType(TypedDict):
+class NestedDict(TypedDict):
     number: int
     string: str
 
 
-class Level2Type(TypedDict):
-    level3: NestedDictType
+class Level2(TypedDict):
+    level3: NestedDict
 
 
-class MultipeLevelsType(TypedDict):
-    level2: Level2Type
+class MultipeLevels(TypedDict):
+    level2: Level2
 
 
-NestedInvalidType = TypedDict("NestedInvalidType", {
+NestedInvalid = TypedDict("NestedInvalid", {
     "numeric-id": int,
     "from": str,
 })
 
 
-class RootType(TypedDict):
+class Root(TypedDict):
     number_int: int
     number_float: float
     string: str
     list_single_type: List[str]
     list_mixed_type: List[Union[float, int, str]]
-    nested_dict: NestedDictType
-    same_nested_dict: NestedDictType
-    multipe_levels: MultipeLevelsType
-    nested_invalid: NestedInvalidType
+    nested_dict: NestedDict
+    same_nested_dict: NestedDict
+    multipe_levels: MultipeLevels
+    nested_invalid: NestedInvalid
     optional_items: List[Union[None, int, str]]
 ```
 
@@ -236,34 +237,34 @@ from typing import List, Union
 from typing_extensions import TypedDict
 
 
-class NestedDictType(TypedDict):
+class NestedDict(TypedDict):
     number: int
     string: str
 
 
-class Level2Type(TypedDict):
-    level3: NestedDictType
+class Level2(TypedDict):
+    level3: NestedDict
 
 
-class MultipeLevelsType(TypedDict):
-    level2: Level2Type
+class MultipeLevels(TypedDict):
+    level2: Level2
 
 
-NestedInvalidType = TypedDict("NestedInvalidType", {
+NestedInvalid = TypedDict("NestedInvalid", {
     "numeric-id": int,
     "from": str,
 })
 
 
-class RootType(TypedDict):
+class Root(TypedDict):
     number_int: int
     number_float: float
     string: str
     list_single_type: List[str]
     list_mixed_type: List[Union[float, int, str]]
-    nested_dict: NestedDictType
-    same_nested_dict: NestedDictType
-    multipe_levels: MultipeLevelsType
-    nested_invalid: NestedInvalidType
+    nested_dict: NestedDict
+    same_nested_dict: NestedDict
+    multipe_levels: MultipeLevels
+    nested_invalid: NestedInvalid
     optional_items: List[Union[None, int, str]]
 ```

--- a/dict_typer/models.py
+++ b/dict_typer/models.py
@@ -174,23 +174,17 @@ class DictEntry:
             out.append(f'{self.name} = TypedDict("{self.name}", {{')
 
             for key, value in self.members.items():
-                if isinstance(value, DictEntry):
-                    out.append(f'{" " * self.indentation}"{key}": {value.name},')
-                else:
-                    out.append(
-                        f'{" " * self.indentation}"{key}": {sub_members_to_string(value)},'
-                    )
+                out.append(
+                    f'{" " * self.indentation}"{key}": {sub_members_to_string(value)},'
+                )
 
             out.append("})")
         else:
             out.append(f"class {self.name}(TypedDict):")
             for key, value in self.members.items():
-                if isinstance(value, DictEntry):
-                    out.append(f"{' ' * self.indentation}{key}: {value.name}")
-                else:
-                    out.append(
-                        f"{' ' * self.indentation}{key}: {sub_members_to_string(value)}"
-                    )
+                out.append(
+                    f"{' ' * self.indentation}{key}: {sub_members_to_string(value)}"
+                )
 
         return "\n".join(out)
 

--- a/dict_typer/models.py
+++ b/dict_typer/models.py
@@ -11,6 +11,12 @@ SubMembers = Set[EntryType]
 DictMembers = Dict[str, SubMembers]
 
 
+def is_valid_name(name: str) -> bool:
+    if not is_valid_key(name):
+        return False
+    return not name in KNOWN_TYPE_IMPORTS
+
+
 def sub_members_to_string(sub_members: SubMembers) -> str:
     def get_member_value(item: EntryType) -> str:
         """ Only reference DictEntry by name. """
@@ -109,7 +115,10 @@ class DictEntry:
         indentation: int = 4,
         force_alternative: bool = False,
     ) -> None:
-        self.name = name
+        if is_valid_name(name):
+            self.name = name
+        else:
+            self.name = f"{name}_"
         self.members = members or {}
         self.indentation = indentation
         self.force_alternative = force_alternative

--- a/dict_typer/models.py
+++ b/dict_typer/models.py
@@ -14,7 +14,7 @@ DictMembers = Dict[str, SubMembers]
 def is_valid_name(name: str) -> bool:
     if not is_valid_key(name):
         return False
-    return not name in KNOWN_TYPE_IMPORTS
+    return name not in KNOWN_TYPE_IMPORTS
 
 
 def sub_members_to_string(sub_members: SubMembers) -> str:

--- a/dict_typer/type_definitions.py
+++ b/dict_typer/type_definitions.py
@@ -43,7 +43,7 @@ class DefinitionBuilder:
         self,
         source: Union[Dict, List],
         root_type_name: str = "Root",
-        type_postfix: str = "Type",
+        type_postfix: str = "",
         show_imports: bool = True,
     ) -> None:
         self.definitions = []
@@ -213,7 +213,7 @@ class DefinitionBuilder:
 def get_type_definitions(
     source: Union[Dict, List],
     root_type_name: str = "Root",
-    type_postfix: str = "Type",
+    type_postfix: str = "",
     show_imports: bool = True,
 ) -> str:
     if not isinstance(source, (list, dict)):

--- a/tests/snapshot/fixtures/README.md
+++ b/tests/snapshot/fixtures/README.md
@@ -6,3 +6,6 @@ The fixtures are borrowed from the [examples section on json.org](https://json.o
 
 # sitepoint.com.exampleX.json
 The fixtures are borrowed from the [10 JSON Examples to Use in Your Projects](https://www.sitepoint.com/10-example-json-files/)
+
+# custom.exampleX.json
+Custom payloads for this library

--- a/tests/snapshot/fixtures/custom.example1.json
+++ b/tests/snapshot/fixtures/custom.example1.json
@@ -1,0 +1,127 @@
+[
+  {
+    "caption": "Lorem ipsum dolor sit amet",
+    "comments": {
+      "data": [
+        {
+          "timestamp": "2020-01-01T10:11:12+0000",
+          "text": "Foo Bar",
+          "id": "123123"
+        },
+        {
+          "timestamp": "2020-01-01T10:11:13+0000",
+          "text": "Baz Qux",
+          "id": "456456"
+        }
+      ]
+    },
+    "comments_count": 2,
+    "id": "123",
+    "ig_id": "123",
+    "is_comment_enabled": true,
+    "like_count": 100,
+    "media_type": "IMAGE",
+    "media_url": "https://example.com/image.jpg",
+    "owner": { "id": "123123" },
+    "permalink": "https://example.com/p/foobar/",
+    "shortcode": "foobar",
+    "timestamp": "2020-01-01T10:11:11+0000",
+    "username": "foobar"
+  },
+  {
+    "caption": "Lorem ipsum dolor sit amet",
+    "children": {
+      "data": [{ "id": "123" }, { "id": "456" }]
+    },
+    "comments": {
+      "data": [
+        {
+          "timestamp": "2020-01-01T10:11:12+0000",
+          "text": "Foo bar",
+          "id": "123"
+        },
+        {
+          "timestamp": "2020-01-01T10:11:12+0000",
+          "text": "Baz qux",
+          "id": "456"
+        }
+      ],
+      "paging": {
+        "cursors": {
+          "after": "ABCDEF"
+        },
+        "next": "https://example.com/ABCDEF"
+      }
+    },
+    "comments_count": 10,
+    "id": "123",
+    "ig_id": "123",
+    "is_comment_enabled": true,
+    "like_count": 100,
+    "media_type": "CAROUSEL_ALBUM",
+    "media_url": "https://example.com/image.jpg",
+    "owner": { "id": "123" },
+    "permalink": "https://www.example.com/foobar/",
+    "shortcode": "foobar",
+    "timestamp": "2020-01-01T10:11:12+0000",
+    "username": "foobar"
+  },
+  {
+    "caption": "Lorem ipsum dolor sit amet",
+    "comments": {
+      "data": [
+        {
+          "timestamp": "2020-01-01T10:11:12+0000",
+          "text": "Foo bar",
+          "id": "123"
+        }
+      ],
+      "paging": {
+        "cursors": {
+          "after": "abc"
+        },
+        "next": "https://example.com/ABCDEF"
+      }
+    },
+    "comments_count": 10,
+    "id": "123",
+    "ig_id": "123",
+    "is_comment_enabled": true,
+    "like_count": 100,
+    "media_type": "IMAGE",
+    "media_url": "https://example.com/image.jpg",
+    "owner": { "id": "123" },
+    "permalink": "https://www.example.com/abc/",
+    "shortcode": "abc",
+    "timestamp": "2020-01-01T10:11:12+0000",
+    "username": "foobar"
+  },
+  {
+    "caption": "Lorem ipsum dolor sit amet",
+    "children": {
+      "data": [{ "id": "123" }, { "id": "123" }]
+    },
+    "comments": {
+      "data": [
+        {
+          "timestamp": "2020-01-01T10:11:12+0000",
+          "text": "Foo Bar",
+          "id": "123"
+        }
+      ]
+    },
+    "comments_count": 10,
+    "id": "123",
+    "ig_id": "123",
+    "is_comment_enabled": true,
+    "like_count": 100,
+    "media_type": "CAROUSEL_ALBUM",
+    "media_url": "https://example.com/image.jpg",
+    "owner": { "id": "123" },
+    "permalink": "https://www.example.com/p/foobar/",
+    "shortcode": "foobar",
+    "timestamp": "2020-01-01T10:11:12+0000",
+    "username": "foobar"
+  }
+]
+

--- a/tests/snapshot/snapshots/snap_test_snapshots.py
+++ b/tests/snapshot/snapshots/snap_test_snapshots.py
@@ -12,72 +12,72 @@ snapshots['test_snapshots[json.org.example1] 1'] = '''from typing import List
 from typing_extensions import TypedDict
 
 
-class GlossDefType(TypedDict):
+class GlossDef(TypedDict):
     para: str
     GlossSeeAlso: List[str]
 
 
-class GlossEntryType(TypedDict):
+class GlossEntry(TypedDict):
     ID: str
     SortAs: str
     GlossTerm: str
     Acronym: str
     Abbrev: str
-    GlossDef: GlossDefType
+    GlossDef: GlossDef
     GlossSee: str
 
 
-class GlossListType(TypedDict):
-    GlossEntry: GlossEntryType
+class GlossList(TypedDict):
+    GlossEntry: GlossEntry
 
 
-class GlossDivType(TypedDict):
+class GlossDiv(TypedDict):
     title: str
-    GlossList: GlossListType
+    GlossList: GlossList
 
 
-class GlossaryType(TypedDict):
+class Glossary(TypedDict):
     title: str
-    GlossDiv: GlossDivType
+    GlossDiv: GlossDiv
 
 
-class RootType(TypedDict):
-    glossary: GlossaryType'''
+class Root(TypedDict):
+    glossary: Glossary'''
 
 snapshots['test_snapshots[json.org.example2] 1'] = '''from typing import List
 
 from typing_extensions import TypedDict
 
 
-class MenuitemItem0Type(TypedDict):
+class MenuitemItem0(TypedDict):
     value: str
     onclick: str
 
 
-class PopupType(TypedDict):
-    menuitem: List[MenuitemItem0Type]
+class Popup(TypedDict):
+    menuitem: List[MenuitemItem0]
 
 
-class MenuType(TypedDict):
+class Menu(TypedDict):
     id: str
     value: str
-    popup: PopupType
+    popup: Popup
 
 
-class RootType(TypedDict):
-    menu: MenuType'''
+class Root(TypedDict):
+    menu: Menu'''
 
 snapshots['test_snapshots[json.org.example3] 1'] = '''from typing_extensions import TypedDict
 
 
-class WindowType(TypedDict):
+class Window(TypedDict):
     title: str
     name: str
     width: int
     height: int
 
 
-class ImageType(TypedDict):
+class Image(TypedDict):
     src: str
     name: str
     hOffset: int
@@ -85,7 +85,7 @@ class ImageType(TypedDict):
     alignment: str
 
 
-class TextType(TypedDict):
+class Text(TypedDict):
     data: str
     size: int
     style: str
@@ -96,22 +96,22 @@ class TextType(TypedDict):
     onMouseUp: str
 
 
-class WidgetType(TypedDict):
+class Widget(TypedDict):
     debug: str
-    window: WindowType
-    image: ImageType
-    text: TextType
+    window: Window
+    image: Image
+    text: Text
 
 
-class RootType(TypedDict):
-    widget: WidgetType'''
+class Root(TypedDict):
+    widget: Widget'''
 
 snapshots['test_snapshots[json.org.example4] 1'] = '''from typing import List, Union
 
 from typing_extensions import TypedDict
 
 
-InitParamType = TypedDict("InitParamType", {
+InitParam = TypedDict("InitParam", {
     "configGlossary:installationAt": str,
     "configGlossary:adminEmail": str,
     "configGlossary:poweredBy": str,
@@ -157,12 +157,12 @@ InitParamType = TypedDict("InitParamType", {
 })
 
 
-class InitParamType1(TypedDict):
+class InitParam1(TypedDict):
     mailHost: str
     mailHostOverride: str
 
 
-class InitParamType2(TypedDict):
+class InitParam2(TypedDict):
     templatePath: str
     log: int
     logLocation: str
@@ -178,20 +178,20 @@ class InitParamType2(TypedDict):
     betaServer: bool
 
 
-ServletItem0Type = TypedDict("ServletItem0Type", {
+ServletItem0 = TypedDict("ServletItem0", {
     "servlet-name": str,
     "servlet-class": str,
-    "init-param": Union[InitParamType, InitParamType1, InitParamType2],
+    "init-param": Union[InitParam, InitParam1, InitParam2],
 })
 
 
-ServletItem2Type = TypedDict("ServletItem2Type", {
+ServletItem2 = TypedDict("ServletItem2", {
     "servlet-name": str,
     "servlet-class": str,
 })
 
 
-class ServletMappingType(TypedDict):
+class ServletMapping(TypedDict):
     cofaxCDS: str
     cofaxEmail: str
     cofaxAdmin: str
@@ -199,21 +199,21 @@ class ServletMappingType(TypedDict):
     cofaxTools: str
 
 
-TaglibType = TypedDict("TaglibType", {
+Taglib = TypedDict("Taglib", {
     "taglib-uri": str,
     "taglib-location": str,
 })
 
 
-WebAppType = TypedDict("WebAppType", {
-    "servlet": List[Union[ServletItem0Type, ServletItem2Type]],
-    "servlet-mapping": ServletMappingType,
-    "taglib": TaglibType,
+WebApp = TypedDict("WebApp", {
+    "servlet": List[Union[ServletItem0, ServletItem2]],
+    "servlet-mapping": ServletMapping,
+    "taglib": Taglib,
 })
 
 
-RootType = TypedDict("RootType", {
-    "web-app": WebAppType,
+Root = TypedDict("Root", {
+    "web-app": WebApp,
 })'''
 
 snapshots['test_snapshots[json.org.example5] 1'] = '''from typing import List, Union
@@ -221,135 +221,135 @@ snapshots['test_snapshots[json.org.example5] 1'] = '''from typing import List, U
 from typing_extensions import TypedDict
 
 
-class ItemsItem0Type(TypedDict):
+class ItemsItem0(TypedDict):
     id: str
 
 
-class ItemsItem1Type(TypedDict):
+class ItemsItem1(TypedDict):
     id: str
     label: str
 
 
-class MenuType(TypedDict):
+class Menu(TypedDict):
     header: str
-    items: List[Union[ItemsItem0Type, ItemsItem1Type, None]]
+    items: List[Union[ItemsItem0, ItemsItem1, None]]
 
 
-class RootType(TypedDict):
-    menu: MenuType'''
+class Root(TypedDict):
+    menu: Menu'''
 
 snapshots['test_snapshots[sitepoint.com.example1] 1'] = '''from typing import List, Union
 
 from typing_extensions import TypedDict
 
 
-class CodeType(TypedDict):
+class Code(TypedDict):
     rgba: List[int]
     hex: str
 
 
-class ColorsItem0Type(TypedDict):
+class ColorsItem0(TypedDict):
     color: str
     category: str
     type: str
-    code: CodeType
+    code: Code
 
 
-class ColorsItem1Type(TypedDict):
+class ColorsItem1(TypedDict):
     color: str
     category: str
-    code: CodeType
+    code: Code
 
 
-class RootType(TypedDict):
-    colors: List[Union[ColorsItem0Type, ColorsItem1Type]]'''
+class Root(TypedDict):
+    colors: List[Union[ColorsItem0, ColorsItem1]]'''
 
 snapshots['test_snapshots[sitepoint.com.example2] 1'] = '''from typing import List, Union
 
 from typing_extensions import TypedDict
 
 
-class MarkersItem0Type(TypedDict):
+class MarkersItem0(TypedDict):
     name: str
     position: List[float]
 
 
-class MarkersItem1Type(TypedDict):
+class MarkersItem1(TypedDict):
     name: str
     location: List[float]
 
 
-class RootType(TypedDict):
-    markers: List[Union[MarkersItem0Type, MarkersItem1Type]]'''
+class Root(TypedDict):
+    markers: List[Union[MarkersItem0, MarkersItem1]]'''
 
 snapshots['test_snapshots[sitepoint.com.example3] 1'] = '''from typing import List, Union
 
 from typing_extensions import TypedDict
 
 
-class PageInfoType(TypedDict):
+class PageInfo(TypedDict):
     totalResults: int
     resultsPerPage: int
 
 
-class IdType(TypedDict):
+class Id(TypedDict):
     kind: str
     channelId: str
 
 
-class IdType1(TypedDict):
+class Id1(TypedDict):
     kind: str
     videoId: str
 
 
-class ItemsItem0Type(TypedDict):
+class ItemsItem0(TypedDict):
     kind: str
     etag: str
-    id: Union[IdType, IdType1]
+    id: Union[Id, Id1]
 
 
-class RootType(TypedDict):
+class Root(TypedDict):
     kind: str
     etag: str
     nextPageToken: str
     regionCode: str
-    pageInfo: PageInfoType
-    items: List[ItemsItem0Type]'''
+    pageInfo: PageInfo
+    items: List[ItemsItem0]'''
 
 snapshots['test_snapshots[sitepoint.com.example4] 1'] = '''from typing import List, Union
 
 from typing_extensions import TypedDict
 
 
-class HashtagsItem0Type(TypedDict):
+class HashtagsItem0(TypedDict):
     text: str
     indices: List[int]
 
 
-class UrlsItem0Type(TypedDict):
+class UrlsItem0(TypedDict):
     url: str
     expanded_url: str
     display_url: str
     indices: List[int]
 
 
-class EntitiesType(TypedDict):
-    hashtags: List[HashtagsItem0Type]
+class Entities(TypedDict):
+    hashtags: List[HashtagsItem0]
     symbols: List
     user_mentions: List
-    urls: List[UrlsItem0Type]
+    urls: List[UrlsItem0]
 
 
-class UrlType(TypedDict):
-    urls: Union[List, List[UrlsItem0Type]]
+class Url(TypedDict):
+    urls: Union[List, List[UrlsItem0]]
 
 
-class EntitiesType1(TypedDict):
-    url: UrlType
-    description: UrlType
+class Entities1(TypedDict):
+    url: Url
+    description: Url
 
 
-class UserType(TypedDict):
+class User(TypedDict):
     id: int
     id_str: str
     name: str
@@ -357,7 +357,7 @@ class UserType(TypedDict):
     location: str
     description: str
     url: str
-    entities: EntitiesType1
+    entities: Entities1
     protected: bool
     followers_count: int
     friends_count: int
@@ -368,15 +368,85 @@ class UserType(TypedDict):
     time_zone: str
 
 
-class RootItem0Type(TypedDict):
+class RootItem0(TypedDict):
     created_at: str
     id: int
     id_str: str
     text: str
     truncated: bool
-    entities: EntitiesType
+    entities: Entities
     source: str
-    user: UserType
+    user: User
 
 
-RootType = List[RootItem0Type]'''
+Root = List[RootItem0]'''
+
+snapshots['test_snapshots[custom.example1] 1'] = '''from typing import List, Union
+
+from typing_extensions import TypedDict
+
+
+class DataItem0(TypedDict):
+    timestamp: str
+    text: str
+    id: str
+
+
+class Comments(TypedDict):
+    data: Union[List[DataItem01], List[DataItem0]]
+
+
+class Owner(TypedDict):
+    id: str
+
+
+class Cursors(TypedDict):
+    after: str
+
+
+class Paging(TypedDict):
+    cursors: Cursors
+    next: str
+
+
+class Comments1(TypedDict):
+    data: List[DataItem0]
+    paging: Paging
+
+
+class RootItem0(TypedDict):
+    caption: str
+    comments: Union[Comments, Comments1]
+    comments_count: int
+    id: str
+    ig_id: str
+    is_comment_enabled: bool
+    like_count: int
+    media_type: str
+    media_url: str
+    owner: Owner
+    permalink: str
+    shortcode: str
+    timestamp: str
+    username: str
+
+
+class RootItem1(TypedDict):
+    caption: str
+    children: Comments
+    comments: Union[Comments, Comments1]
+    comments_count: int
+    id: str
+    ig_id: str
+    is_comment_enabled: bool
+    like_count: int
+    media_type: str
+    media_url: str
+    owner: Owner
+    permalink: str
+    shortcode: str
+    timestamp: str
+    username: str
+
+
+Root = List[Union[RootItem0, RootItem1]]'''

--- a/tests/snapshot/test_snapshots.py
+++ b/tests/snapshot/test_snapshots.py
@@ -28,6 +28,7 @@ def sitepoint_com_fixture(num: int) -> Union[Dict, List]:
         "sitepoint.com.example2",
         "sitepoint.com.example3",
         "sitepoint.com.example4",
+        "custom.example1",
     ],
 )
 def test_snapshots(snapshot: Any, fixture: str) -> None:

--- a/tests/unit/test_convert_basics.py
+++ b/tests/unit/test_convert_basics.py
@@ -9,7 +9,7 @@ def test_convert_simple_json() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    id: int",
         "    item: str",
         "    progress: float",
@@ -47,7 +47,7 @@ def test_convert_base_types() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    bool_type: bool",
         "    bytearray_type: bytearray",
         "    bytes_types: bytes",
@@ -79,7 +79,7 @@ def test_convert_none() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    value: None",
     ])
     # fmt: on

--- a/tests/unit/test_convert_dict_in_sequence.py
+++ b/tests/unit/test_convert_dict_in_sequence.py
@@ -11,12 +11,12 @@ def test_convert_list_of_repeated_dicts() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class DictListItem0Type(TypedDict):",
+        "class DictListItem0(TypedDict):",
         "    id: int",
         "",
         "",
-        "class RootType(TypedDict):",
-        "    dictList: List[DictListItem0Type]",
+        "class Root(TypedDict):",
+        "    dictList: List[DictListItem0]",
     ])
     # fmt: on
 
@@ -33,20 +33,20 @@ def test_convert_list_of_mixed_dicts() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class DictListItem0Type(TypedDict):",
+        "class DictListItem0(TypedDict):",
         "    foo: int",
         "",
         "",
-        "class DictListItem1Type(TypedDict):",
+        "class DictListItem1(TypedDict):",
         "    bar: int",
         "",
         "",
-        "class DictListItem2Type(TypedDict):",
+        "class DictListItem2(TypedDict):",
         "    baz: int",
         "",
         "",
-        "class RootType(TypedDict):",
-        "    dictList: List[Union[DictListItem0Type, DictListItem1Type, DictListItem2Type]]",
+        "class Root(TypedDict):",
+        "    dictList: List[Union[DictListItem0, DictListItem1, DictListItem2]]",
     ])
     # fmt: on
 
@@ -63,12 +63,12 @@ def test_convert_list_of_repeated_dicts_different_types_combined() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class DictListItem0Type(TypedDict):",
+        "class DictListItem0(TypedDict):",
         "    id: Union[float, int, str]",
         "",
         "",
-        "class RootType(TypedDict):",
-        "    dictList: List[DictListItem0Type]",
+        "class Root(TypedDict):",
+        "    dictList: List[DictListItem0]",
     ])
     # fmt: on
 

--- a/tests/unit/test_convert_dicts.py
+++ b/tests/unit/test_convert_dicts.py
@@ -11,7 +11,7 @@ def test_convert_empty_root_dict() -> None:
         "from typing import Dict",
         "",
         "",
-        "RootType = Dict",
+        "Root = Dict",
     ])
     # fmt: on
 
@@ -28,7 +28,7 @@ def test_convert_with_nested_empty_dict() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    nest: Dict",
     ])
     # fmt: on
@@ -44,12 +44,12 @@ def test_convert_with_nested_dict() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class NestType(TypedDict):",
+        "class Nest(TypedDict):",
         "    foo: str",
         "",
         "",
-        "class RootType(TypedDict):",
-        "    nest: NestType",
+        "class Root(TypedDict):",
+        "    nest: Nest",
     ])
     # fmt: on
 
@@ -64,20 +64,20 @@ def test_convert_with_multiple_levels_nested_dict() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class Level3Type(TypedDict):",
+        "class Level3(TypedDict):",
         "    level4: str",
         "",
         "",
-        "class Level2Type(TypedDict):",
-        "    level3: Level3Type",
+        "class Level2(TypedDict):",
+        "    level3: Level3",
         "",
         "",
-        "class Level1Type(TypedDict):",
-        "    level2: Level2Type",
+        "class Level1(TypedDict):",
+        "    level2: Level2",
         "",
         "",
-        "class RootType(TypedDict):",
-        "    level1: Level1Type",
+        "class Root(TypedDict):",
+        "    level1: Level1",
     ])
     # fmt: on
 
@@ -92,17 +92,17 @@ def test_convert_with_multiple_nested_dict() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class NestType(TypedDict):",
+        "class Nest(TypedDict):",
         "    foo: str",
         "",
         "",
-        "class OtherNestType(TypedDict):",
+        "class OtherNest(TypedDict):",
         "    baz: str",
         "",
         "",
-        "class RootType(TypedDict):",
-        "    nest: NestType",
-        "    other_nest: OtherNestType",
+        "class Root(TypedDict):",
+        "    nest: Nest",
+        "    other_nest: OtherNest",
     ])
     # fmt: on
 
@@ -121,18 +121,18 @@ def test_convert_with_repeated_nested_dict() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class NestType(TypedDict):",
+        "class Nest(TypedDict):",
         "    foo: str",
         "",
         "",
-        "class UniqueNestType(TypedDict):",
+        "class UniqueNest(TypedDict):",
         "    baz: str",
         "",
         "",
-        "class RootType(TypedDict):",
-        "    nest: NestType",
-        "    other_nest: NestType",
-        "    unique_nest: UniqueNestType",
+        "class Root(TypedDict):",
+        "    nest: Nest",
+        "    other_nest: Nest",
+        "    unique_nest: UniqueNest",
     ])
     # fmt: on
 
@@ -152,19 +152,19 @@ def test_convert_nested_overlapping_dict() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class XType(TypedDict):",
+        "class X(TypedDict):",
         "    foo: str",
         "",
         "",
-        "class XType1(TypedDict):",
+        "class X1(TypedDict):",
         "    baz: str",
         "",
         "",
-        "class RootItem0Type(TypedDict):",
-        "    x: Union[XType, XType1]",
+        "class RootItem0(TypedDict):",
+        "    x: Union[X, X1]",
         "",
         "",
-        "RootType = List[RootItem0Type]",
+        "Root = List[RootItem0]",
     ])
     # fmt: on
 

--- a/tests/unit/test_convert_imports.py
+++ b/tests/unit/test_convert_imports.py
@@ -10,7 +10,7 @@ def test_convert_hides_import_optionally() -> None:
 
     # fmt: off
     expected = "\n".join([
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    itemsList: List[Union[float, int, str]]",
         "    itemsTuple: Tuple[int]",
         "    itemsSet: Set[Union[float, int]]",
@@ -30,13 +30,13 @@ def test_convert_optionally_adds_imports_with_nested_defs() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class NestType(TypedDict):",
+        "class Nest(TypedDict):",
         "    itemsTuple: Tuple[Union[Set[Union[float, int]], int]]",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    itemsList: List[int]",
-        "    nest: NestType",
+        "    nest: Nest",
     ])
     # fmt: on
 
@@ -51,7 +51,7 @@ def test_convert_imports_with_no_typing_imports() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    id: int",
         "    value: str",
     ])
@@ -68,7 +68,7 @@ def test_convert_imports_with_no_typed_dict() -> None:
         "from typing import List",
         "",
         "",
-        "RootType = List[int]",
+        "Root = List[int]",
     ])
     # fmt: on
 

--- a/tests/unit/test_convert_lists.py
+++ b/tests/unit/test_convert_lists.py
@@ -13,7 +13,7 @@ def test_convert_with_empty_list() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    items: List",
     ])
     # fmt: on
@@ -29,7 +29,7 @@ def test_convert_empty_root_list() -> None:
         "from typing import List",
         "",
         "",
-        "RootType = List",
+        "Root = List",
     ])
     # fmt: on
 
@@ -46,7 +46,7 @@ def test_convert_with_simple_list() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    items: List[int]",
     ])
     # fmt: on
@@ -64,7 +64,7 @@ def test_convert_with_mixed_list() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    items: List[Union[float, int, str]]",
     ])
     # fmt: on

--- a/tests/unit/test_convert_optional.py
+++ b/tests/unit/test_convert_optional.py
@@ -9,7 +9,7 @@ def test_convert_single_optional_in_list() -> None:
         "from typing import List, Optional",
         "",
         "",
-        "RootType = List[Optional[int]]",
+        "Root = List[Optional[int]]",
     ])
     # fmt: on
 
@@ -24,7 +24,7 @@ def test_convert_not_optional_if_multiple_types_with_none() -> None:
         "from typing import List, Union",
         "",
         "",
-        "RootType = List[Union[None, float, int]]",
+        "Root = List[Union[None, float, int]]",
     ])
     # fmt: on
 
@@ -44,14 +44,14 @@ def test_convert_optional_combined_dicts() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class OwnerType(TypedDict):",
+        "class Owner(TypedDict):",
         "    name: str",
         "    age: Optional[int]",
         "",
         "",
-        "class RootType(TypedDict):",
-        "    owner: OwnerType",
-        "    coOwner: OwnerType",
+        "class Root(TypedDict):",
+        "    owner: Owner",
+        "    coOwner: Owner",
     ])
     # fmt: on
 

--- a/tests/unit/test_convert_root_list.py
+++ b/tests/unit/test_convert_root_list.py
@@ -11,11 +11,11 @@ def test_convert_root_list_single_item() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootItem0Type(TypedDict):",
+        "class RootItem0(TypedDict):",
         "    id: int",
         "",
         "",
-        "RootType = List[RootItem0Type]",
+        "Root = List[RootItem0]",
     ])
     # fmt: on
 
@@ -36,11 +36,11 @@ def test_convert_root_list_multiple_items() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootItem0Type(TypedDict):",
+        "class RootItem0(TypedDict):",
         "    id: int",
         "",
         "",
-        "RootType = List[RootItem0Type]",
+        "Root = List[RootItem0]",
     ])
     # fmt: on
 
@@ -62,15 +62,15 @@ def test_convert_root_list_multiple_mixed_items() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootItem0Type(TypedDict):",
+        "class RootItem0(TypedDict):",
         "    id: int",
         "",
         "",
-        "class RootItem1Type(TypedDict):",
+        "class RootItem1(TypedDict):",
         "    value: str",
         "",
         "",
-        "RootType = List[Union[RootItem0Type, RootItem1Type]]",
+        "Root = List[Union[RootItem0, RootItem1]]",
     ])
     # fmt: on
 
@@ -85,7 +85,7 @@ def test_convert_root_list_mixed_non_dict() -> None:
         "from typing import List, Union",
         "",
         "",
-        "RootType = List[Union[float, int, str]]",
+        "Root = List[Union[float, int, str]]",
     ])
     # fmt: on
 

--- a/tests/unit/test_convert_set.py
+++ b/tests/unit/test_convert_set.py
@@ -11,7 +11,7 @@ def test_convert_with_empty_set() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    items: Set",
     ])
     # fmt: on
@@ -29,7 +29,7 @@ def test_convert_with_simple_set() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    items: Set[int]",
     ])
     # fmt: on
@@ -47,7 +47,7 @@ def test_convert_with_mixed_set() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    items: Set[Union[float, int, str]]",
     ])
     # fmt: on

--- a/tests/unit/test_convert_tuple.py
+++ b/tests/unit/test_convert_tuple.py
@@ -11,7 +11,7 @@ def test_convert_with_empty_tuple() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    items: Tuple",
     ])
     # fmt: on
@@ -29,7 +29,7 @@ def test_convert_with_simple_tuple() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    items: Tuple[int]",
     ])
     # fmt: on
@@ -47,7 +47,7 @@ def test_convert_with_mixed_tuple() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class RootType(TypedDict):",
+        "class Root(TypedDict):",
         "    items: Tuple[Union[float, int, str]]",
     ])
     # fmt: on

--- a/tests/unit/test_convert_with_invalid_key_names.py
+++ b/tests/unit/test_convert_with_invalid_key_names.py
@@ -9,7 +9,7 @@ def test_convert_with_invalid_key_names() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        'RootType = TypedDict("RootType", {',
+        'Root = TypedDict("Root", {',
         '    "invalid-key": int,',
         '    "from": str,',
         '})'
@@ -27,12 +27,12 @@ def test_convert_with_invalid_key_names_nested() -> None:
         "from typing_extensions import TypedDict",
         "",
         "",
-        "class InvalidKeyType(TypedDict):",
+        "class InvalidKey(TypedDict):",
         "    id: int",
         "",
         "",
-        'RootType = TypedDict("RootType", {',
-        '    "invalid-key": InvalidKeyType,',
+        'Root = TypedDict("Root", {',
+        '    "invalid-key": InvalidKey,',
         '})'
     ])
     # fmt: on

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -227,3 +227,8 @@ def test_sorting_dict_entry_with_sub_entry() -> None:
 
     assert sorted([entry, sub_entry], key=key_to_dependency_cmp) == [sub_entry, entry]
     assert sorted([sub_entry, entry], key=key_to_dependency_cmp) == [sub_entry, entry]
+
+
+def test_dict_entry_invalid_name_adds_underscore() -> None:
+    assert DictEntry("List").name == "List_"
+    assert DictEntry("None").name == "None_"


### PR DESCRIPTION
Makes the output cleaner, but keeps the option of having a postfix.

Will this require verifying that the type name isn't overlapping any reserved word or overwriting existing imports?

Minimal example:

```json
{
	"list": {
		"items": [1, 2, 3]
	}
}
```

which now produces 

```python
from typing import List

from typing_extensions import TypedDict


class List(TypedDict):
    items: List[int]


class Root(TypedDict):
    list: List
```